### PR TITLE
Fixed naming of fileSizeReportModulePath

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ import { reportFileSizeImpact, readGitHubWorkflowEnv } from "@jsenv/file-size-im
 await reportFileSizeImpact({
   ...readGitHubWorkflowEnv(),
   buildCommand: "npm run dist",
-  fileSizeModulePath: "./generate_file_size_report.mjs",
+  fileSizeReportModulePath: "./generate_file_size_report.mjs",
 })
 ```
 
@@ -320,7 +320,7 @@ await reportFileSizeImpact({
 
   installCommand: "npm install",
   buildCommand: "npm run build",
-  fileSizeModulePath: "./generate_file_size_report.mjs",
+  fileSizeReportModulePath: "./generate_file_size_report.mjs",
 
   filesOrdering: "size_impact",
 })

--- a/readme.md
+++ b/readme.md
@@ -118,9 +118,11 @@ import { reportFileSizeImpact, readGitHubWorkflowEnv } from "@jsenv/file-size-im
 await reportFileSizeImpact({
   ...readGitHubWorkflowEnv(),
   buildCommand: "npm run dist",
-  fileSizeReportModulePath: "./generate_file_size_report.mjs",
+  fileSizeReportModulePath: "./generate_file_size_report.mjs#fileSizeReport",
 })
 ```
+
+where `fileSizeReport` is the name of the export from _generate_file_size_report.mjs_.
 
 ## Other tools
 
@@ -320,7 +322,7 @@ await reportFileSizeImpact({
 
   installCommand: "npm install",
   buildCommand: "npm run build",
-  fileSizeReportModulePath: "./generate_file_size_report.mjs",
+  fileSizeReportModulePath: "./generate_file_size_report.mjs#fileSizeReport",
 
   filesOrdering: "size_impact",
 })

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ _generate_file_size_report.mjs_
 ```js
 import { generateFileSizeReport } from "@jsenv/file-size-impact"
 
-export const filesizeReport = await generateFileSizeReport({
+export const fileSizeReport = await generateFileSizeReport({
   log: process.argv.includes("--log"),
   projectDirectoryUrl: new URL("./", import.meta.url),
   trackingConfig: {


### PR DESCRIPTION
Apparently this was changed, at least with the examples from the README this did not work. I had to change it. The source code confirmed this.

Hope that's right - or maybe I am using it wrong?

Thanks for providing this tool and having such an extensive README! 🚀 